### PR TITLE
fix(FormApi): fix type errors and wrong variable usage

### DIFF
--- a/packages/form-core/src/FormApi.ts
+++ b/packages/form-core/src/FormApi.ts
@@ -1972,14 +1972,14 @@ export class FormApi<
     const fieldValue = this.getFieldValue(field)
 
     const lastIndex = Array.isArray(fieldValue)
-      ? Math.max(fieldValue.length - 1, 0)
+      ? Math.max((fieldValue as unknown[]).length - 1, 0)
       : null
 
     this.setFieldValue(field, [] as any, opts)
 
     if (lastIndex !== null) {
       for (let i = 0; i <= lastIndex; i++) {
-        const fieldKey = `${field}[${lastIndex}]`
+        const fieldKey = `${field}[${i}]`
         this.deleteField(fieldKey as never)
       }
     }
@@ -2007,7 +2007,9 @@ export class FormApi<
     const { thisArg, ...metaOpts } = opts ?? {}
     const fieldValue = this.getFieldValue(field)
 
-    const previousLength = Array.isArray(fieldValue) ? fieldValue.length : null
+    const previousLength = Array.isArray(fieldValue)
+      ? (fieldValue as unknown[]).length
+      : null
 
     const remainingIndeces: number[] = []
     this.setFieldValue(

--- a/packages/form-core/tests/FormApi.spec.ts
+++ b/packages/form-core/tests/FormApi.spec.ts
@@ -2922,7 +2922,7 @@ describe('form api', () => {
     })
     form.mount()
 
-    form.clearValues('employees')
+    form.clearFieldValues('employees')
 
     expect(form.getFieldValue('employees')).toEqual([])
     expect(form.getFieldValue(`employees[0]`)).toBeUndefined()
@@ -2963,7 +2963,7 @@ describe('form api', () => {
     expect(form.getFieldValue('items')).toEqual(['a', 'b', 'd', 'f'])
   })
 
-  it.only('should shift meta when calling filterFieldValues', () => {
+  it('should shift meta when calling filterFieldValues', () => {
     const form = new FormApi({
       defaultValues: {
         items: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],


### PR DESCRIPTION
Had a wrongly set index and a couple type errors lingering around. Likely from the merge.

`FormApi.spec.ts` also had a `it.only` in there. Kind of embarasssing, but I was too busy figuring out GH's UI to notice.